### PR TITLE
Make parsing more reliable

### DIFF
--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -57,9 +57,11 @@
 ;;; Code:
 
 (defun exec-path-from-shell-getenv (name)
-  (replace-regexp-in-string
-   "[ \t\n]*$" ""
-   (shell-command-to-string (format "$SHELL --login -i -c 'echo $%s'" name))))
+  (with-temp-buffer
+    (call-process (getenv "SHELL") nil (current-buffer) nil
+                  "--login" "-i" "-c" (concat "echo __RESULT=$" name))
+    (when (re-search-backward "__RESULT=\\(.*\\)" nil t)
+      (match-string 1))))
 
 ;;;###autoload
 (defun exec-path-from-shell-copy-env (name)


### PR DESCRIPTION
`exec-path-from-getenv` isn't reliable, because it assumes that the `$PATH` is the only output of the subprocess.  A shell however may emit more output from the user's shell configuration files, i.e. a welcome message from `fortune` or something the like of.  In such cases, `exec-path` and `$PATH` are spoiled and become useless, because arbitrary strings end up there.

This patch is my attempt to fix this short-coming.  I insert a marker string (`__RESULT=`) into the `echo` command, and search the output of the subprocess for this marker.

I've also replaced `shell-command-to-string` with a direct call to `call-process` because it's somewhat absurd to use a shell to spawn the shell ;)
