### PR TITLE
Fix NUL character introducing escape secuence for octal values

### DIFF
--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -76,7 +76,7 @@ and may therefore contain backslashed escape sequences, but must not
 contain the '%' character."
   (with-temp-buffer
     (call-process (getenv "SHELL") nil (current-buffer) nil
-                  "--login" "-i" "-c" (concat "printf \"__RESULT\\0" str "\""))
+                  "--login" "-i" "-c" (concat "printf \"__RESULT\\x00" str "\""))
     (goto-char (point-min))
     (when (re-search-forward "__RESULT\0\\(.*\\)" nil t)
       (match-string 1))))
@@ -89,7 +89,7 @@ of (NAME . VALUE) pairs."
   (let ((values
          (split-string
           (exec-path-from-shell-printf
-           (mapconcat (lambda (n) (concat "$" n)) names "\\0"))
+           (mapconcat (lambda (n) (concat "$" n)) names "\\x00"))
           "\0"))
         result)
     (while names


### PR DESCRIPTION
We now use hex escape to inject the NUL character.

NUL characters start escape sequence for inserting a byte given its octal
value. This caused problems when environment variables had digit values. For
example, if the value of the variable SSH_AGENT_PID is "46", the command
`printf "\046"` would result, and the output would be `&`, as 046 is the octal
value for the ampersand character.
