### PR TITLE
Remove unnecessary dash to appease old csh

### DIFF
--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -154,7 +154,7 @@ shell-escaped, so they may contain $ etc."
 
 Execute $SHELL according to `exec-path-from-shell-arguments'.
 The result is a list of (NAME . VALUE) pairs."
-  (let* ((dollar-names (mapcar (lambda (n) (format "${%s-}" n)) names))
+  (let* ((dollar-names (mapcar (lambda (n) (format "${%s}" n)) names))
          (values (split-string (exec-path-from-shell-printf
                                 (mapconcat #'identity (make-list (length names) "%s") "\\000")
                                 dollar-names) "\0")))


### PR DESCRIPTION
/bin/csh on Red Hat 5 that I use is a symlink to tcsh version 6.14 built over 10 years ago.
This csh fails due to presence of the dash.
Removing the dash resolved the problem for me.
I don't know what the purpose of the dash was in the first place.
If it was an optional character, then I would suggest that you remove this to allow older shells to work.