### PR TITLE
Remove code that results on -l shell option

### DIFF
--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -98,7 +98,7 @@
   (if (exec-path-from-shell--tcsh-p shell) "-d" "-l"))
 
 (defcustom exec-path-from-shell-arguments
-  (list (exec-path-from-shell--login-arg (getenv "SHELL")) "-i")
+  (list "-i")
   "Additional arguments to pass to the shell.
 
 The default value denotes an interactive login shell."


### PR DESCRIPTION
(exec-path-from-shell--login-arg (getenv "SHELL"))
produces -l when I'm using /bin/csh on Red Hat 5.

When -l is combined with other shell options, /bin/csh fails.
Perhaps it is because my csh is so old (older than 10 years).
Perhaps it is just illegal to be combining -l with any other shell
option according to the following quote of csh manual:

     -l     The shell is a login shell (only applicable if -l is the only flag
            specified).

I share this pull request not expecting it to be accepted, but just to
highlight the problem I face when using old csh.

I don't know what the proper solution is, because I don't understand
what the purpose of (exec-path-from-shell--login-arg (getenv "SHELL"))
expression is.  I'll be willing to help resolve this problem if I can.