### PR TITLE
Recommend comparing window-system with ns only

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Usage
 Add the following to your `init.el` (after calling `package-initialize`):
 
 ```el
-(when (memq window-system '(mac ns))
+(when (eq window-system 'ns)
   (exec-path-from-shell-initialize))
 ```
 

--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -62,7 +62,7 @@
 ;; If you use your Emacs config on other platforms, you can instead
 ;; make initialization conditional as follows:
 ;;
-;;     (when (memq window-system '(mac ns))
+;;     (when (eq window-system 'ns)
 ;;       (exec-path-from-shell-initialize))
 ;;
 ;; Alternatively, you can use `exec-path-from-shell-copy-envs' or


### PR DESCRIPTION
In the [Window Systems](https://www.gnu.org/software/emacs/manual/html_node/elisp/Window-Systems.html) section of the Emacs manual (and the documentation for variable `window-system`), `ns` is mentioned but `mac` is not. Since this package seems to only be designed for Unix flavors of macOS (10+), checking the `window-system` variable against `'ns` should be enough.