### PR TITLE
Also run on Linux in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ Usage
 Add the following to your `init.el` (after calling `package-initialize`):
 
 ```el
-(when (memq window-system '(mac ns))
+(when (memq window-system '(mac ns x))
   (exec-path-from-shell-initialize))
 ```
 
-This sets `$MANPATH`, `$PATH` and `exec-path` from your shell, but only on OS X.
+This sets `$MANPATH`, `$PATH` and `exec-path` from your shell, but only on OS X
+and Linux.
 
 You can copy values of other environment variables by customizing
 `exec-path-from-shell-variables` before invoking

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can copy values of other environment variables by customizing
 
 This function may also be called interactively.
 
-Note that your shell will inherit Emacssenvironment variables when
+Note that your shell will inherit Emacs's environment variables when
 it is run -- to avoid surprises your config files should therefore
 set the environment variables to their exact desired final values,
 i.e. don't do this:


### PR DESCRIPTION
In an X windows environment (and probably eventually Wayland) you often run into the same problems as on OS X.

Also, I fixed a small typo about "Emacssenvironment" which was more involved than it should be... See https://lists.gnu.org/archive/html/emacs-devel/2012-02/msg00695.html and other messages in that thread. Also, all the documentation appears to use "Emacs's" even though "Emacs'" might seem more logical, so I went with that.