### PR TITLE
fix usage code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Usage
 Add the following to your `init.el` (after calling `package-initialize`):
 
 ```el
-(when (memq window-system '(mac ns x))
+(when (memq window-system '(ns x nil))
   (exec-path-from-shell-initialize))
 ```
 

--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -62,7 +62,7 @@
 ;; If you use your Emacs config on other platforms, you can instead
 ;; make initialization conditional as follows:
 ;;
-;;     (when (memq window-system '(mac ns))
+;;     (when (memq window-system '(ns x nil))
 ;;       (exec-path-from-shell-initialize))
 ;;
 ;; Alternatively, you can use `exec-path-from-shell-copy-envs' or


### PR DESCRIPTION
Hi,

From documentation, it seems that `window-system` cannot take value `mac`. Moreover, `nil` should be added in case someone run Emacs in terminal (sometimes I do).