### PR TITLE
Declare a variable for the byte compiler

### DIFF
--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -72,6 +72,9 @@
 
 ;;; Code:
 
+;; Satisfy the byte compiler
+(defvar eshell-path-env)
+
 (defgroup exec-path-from-shell nil
   "Make Emacs use shell-defined values for $PATH etc."
   :prefix "exec-path-from-shell-"


### PR DESCRIPTION
Without this, I get 

```
In exec-path-from-shell-setenv:
exec-path-from-shell.el:207:11:Warning: assignment to free variable
    ‘eshell-path-env’
```