### PR TITLE
Add `exec-path-from-shell-rc-file-path` to source rc file correctly

### DIFF
--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -128,6 +128,16 @@ The default value denotes an interactive login shell."
   :type '(repeat (string :tag "Shell argument"))
   :group 'exec-path-from-shell)
 
+(defcustom exec-path-from-shell-rc-file-path
+  nil
+  "File path sourced just before getting environment variables.
+
+Default value is nil.  If nil, no file sourced."
+  :type '(choice
+          (const nil)
+          (string))
+  :group 'exec-path-from-shell)
+
 (defun exec-path-from-shell--debug (msg &rest args)
   "Print MSG and ARGS like `message', but only if debug output is enabled."
   (when exec-path-from-shell-debug
@@ -151,7 +161,10 @@ in place of any % placeholders in STR.  ARGS are not automatically
 shell-escaped, so they may contain $ etc."
   (let* ((printf-bin (or (executable-find "printf") "printf"))
          (printf-command
-          (concat printf-bin
+          (concat (if exec-path-from-shell-rc-file-path
+                      (concat "source " exec-path-from-shell-rc-file-path ">/dev/null; ")
+                      "")
+                  printf-bin
                   " '__RESULT\\000" str "\\000__RESULT' "
                   (mapconcat #'exec-path-from-shell--double-quote args " ")))
          (shell (exec-path-from-shell--shell))


### PR DESCRIPTION
Hi.

## Problem

I use Emacs.app on OSX.  The application is launched without my normal shell environment.  So I have to use correctly this package; launch shell in emacs and get variable.

I have separated bash/zsh configuration files and one of them `~/.zsh.d/foobar/path.sh` is about exporting environment variable `PATH`.  So I thought that correct way to tell `exec-path-from-shell` to use this file is the below setting:

```
(require 'exec-path-from-shell)
(setq exec-path-from-shell-shell-name "bash"
      exec-path-from-shell-arguments '("--rcfile" "~/.zsh.d/hoge/path.sh"))
(exec-path-from-shell-initialize)
```

Althogh it does not work.  AFAIK, reading `man bash` and examined as below, `--rcfile` option is not available in non-interactive mode, and there's no way to source before executing command (of `-c` option).

```
$ echo $SHELL
/usr/local/bin/zsh
$ echo 'echo hoge' > rc.sh
$ bash --rcfile rc.sh -c 'printf foobar'
foobar% 
$ bash --login --rcfile rc.sh -c 'printf foobar'
foobar% 
# Here, % is zsh's output for non correctly terminated lines.
```

## Solution

Use explicit `source` before target command.

```
$ bash -c "source $PWD/rc.sh; printf foobar"
hoge
foobar% 
```

This is archived by this PR.  I added new variable `exec-path-from-shell-rc-file-path` for the sourced file path string, because the existing variable `exec-path-from-shell-arguments` is not sufficient for it.

I tested with below setting and it works correctly:

```
(setq exec-path-from-shell-shell-name "bash"
      exec-path-from-shell-arguments '()
      exec-path-from-shell-rc-file-path "~/.zsh.d/hoge/path.sh")
```

What do you think?