### PR TITLE
update the init snippet in readme for more accurately OS detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Usage
 Add the following to your `init.el` (after calling `package-initialize`):
 
 ```el
-(when (memq window-system '(mac ns x))
+(when (memq system-type '(darwin gnu/linux))
   (exec-path-from-shell-initialize))
 ```
 


### PR DESCRIPTION
The original snippet use a `window-system` to determine whether to copy the outisde PATH, it might not work well when emacs start as a daemon. 

Until "Starting Emacs daemon." be messaged in daemon mode, the value of `window-system` would always been `nil`.

[window-system](http://www.gnu.org/software/emacs/manual/html_node/elisp/Window-Systems.html): 
> When Emacs is invoked as a daemon, it does not create any initial frames, so initial-window-system is nil

`system-type` could return a correct OS type in daemon mode.

doc: [system-type](http://www.gnu.org/software/emacs/manual/html_node/elisp/System-Environment.html)