### PR TITLE
Show error if trying to run from a remote buffer

### DIFF
--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -180,6 +180,8 @@ shell-escaped, so they may contain $ etc."
 
 Execute the shell according to `exec-path-from-shell-arguments'.
 The result is a list of (NAME . VALUE) pairs."
+  (when (file-remote-p default-directory)
+    (error "You cannot run exec-path-from-shell from a remote buffer (Tramp, etc.)"))
   (let* ((random-default (md5 (format "%s%s%s" (emacs-pid) (random) (current-time))))
          (dollar-names (mapcar (lambda (n) (format "${%s-%s}" n random-default)) names))
          (values (split-string (exec-path-from-shell-printf


### PR DESCRIPTION
In order to produce sensible results, exec-path-from-shell needs to
run the shell on the same computer where Emacs is running. If we try
to run it on a remote computer, we will likely mess up the local
computer's path or fail to obtain a path altogether.