### PR TITLE
Set each instance of the buffer local variable eshell-path-env

### DIFF
--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -225,8 +225,14 @@ Additionally, if NAME is \"PATH\" then also update the
 variables `exec-path' and `eshell-path-env'."
   (setenv name value)
   (when (string-equal "PATH" name)
-    (setq eshell-path-env value
-          exec-path (append (parse-colon-path value) (list exec-directory)))))
+    (setq exec-path (append (parse-colon-path value) (list exec-directory)))
+    ;; `eshell-path-env' is a buffer local variable so we set the default value
+    ;; and then set the value in each `eshell' buffer.
+    (setq-default eshell-path-env value)
+    (dolist (buffer (buffer-list))
+      (with-current-buffer buffer
+        (when (derived-mode-p 'eshell-mode)
+          (setq eshell-path-env value))))))
 
 ;;;###autoload
 (defun exec-path-from-shell-copy-envs (names)

--- a/exec-path-from-shell.el
+++ b/exec-path-from-shell.el
@@ -226,13 +226,9 @@ variables `exec-path' and `eshell-path-env'."
   (setenv name value)
   (when (string-equal "PATH" name)
     (setq exec-path (append (parse-colon-path value) (list exec-directory)))
-    ;; `eshell-path-env' is a buffer local variable so we set the default value
-    ;; and then set the value in each `eshell' buffer.
-    (setq-default eshell-path-env value)
-    (dolist (buffer (buffer-list))
-      (with-current-buffer buffer
-        (when (derived-mode-p 'eshell-mode)
-          (setq eshell-path-env value))))))
+    ;; `eshell-path-env' is a buffer local variable, so change its default
+    ;; value.
+    (setq-default eshell-path-env value)))
 
 ;;;###autoload
 (defun exec-path-from-shell-copy-envs (names)


### PR DESCRIPTION
This changes the function `exec-path-from-shell-setenv` to set the value of `eshell-path-env` in each existing Eshell buffer. This is because `eshell-path-env` is a buffer local variable.

To me this seems like expected behavior--that we would be changing all instances of the variable.

However, it could be surprising to people who expect `exec-path-from-shell` to not affect running shells.

What does everyone think? Is this a good change to make?